### PR TITLE
Fixes for python 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+brotli
 pycryptodome
-werkzeug
+secure-cookie

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-PyCrypto>=2.5
+pycryptodome
 werkzeug

--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,11 @@ setup(
     description='Werkzeug encrypted cookie',
     packages=['werkzeug_encryptedcookie'],
     platforms='any',
-    install_requires=['pycryptodome', 'werkzeug', 'brotli'],
+    install_requires=['pycryptodome', 'secure_cookie', 'brotli'],
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     description='Werkzeug encrypted cookie',
     packages=['werkzeug_encryptedcookie'],
     platforms='any',
-    install_requires=['PyCrypto>=2.5', 'werkzeug', 'brotli'],
+    install_requires=['pycryptodome', 'werkzeug', 'brotli'],
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     description='Werkzeug encrypted cookie',
     packages=['werkzeug_encryptedcookie'],
     platforms='any',
-    install_requires=['pycryptodome', 'secure_cookie', 'brotli'],
+    install_requires=['pycryptodome', 'secure-cookie', 'brotli'],
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',

--- a/werkzeug_encryptedcookie/__init__.py
+++ b/werkzeug_encryptedcookie/__init__.py
@@ -8,8 +8,7 @@ import brotli
 from Crypto import Random
 from Crypto.Cipher import ARC4
 from Crypto.Hash import SHA
-from werkzeug._internal import _date_to_unix
-from werkzeug.contrib.securecookie import SecureCookie
+from secure_cookie.cookie import _date_to_unix, SecureCookie
 
 
 class EncryptedCookie(SecureCookie):


### PR DESCRIPTION
Updates for Python3.8
- Code for working with cookies was moved from werkzeug to separate module (https://pypi.org/project/secure-cookie/)
- PyCrypto doesn't work with Python 3.8, but pycryptodome (https://pypi.org/project/pycryptodome/) works and has same API  (https://www.pycryptodome.org/en/latest/src/vs_pycrypto.html)